### PR TITLE
Update versions and fix deprecation warnings and errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ inherit_gem:
     - config/rails.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.0.4
 ```
 
 ## Contributing

--- a/config/bundle.yml
+++ b/config/bundle.yml
@@ -94,7 +94,7 @@ Layout/IndentationWidth:
   Width: 2
 
 Layout/LineLength:
-  IgnoredPatterns: [(\A|\s)#]
+  AllowedPatterns: [(\A|\s)#]
   Max: 100
 
 Layout/MultilineArrayLineBreaks:

--- a/config/default.yml
+++ b/config/default.yml
@@ -93,7 +93,7 @@ Layout/IndentationWidth:
   Width: 2
 
 Layout/LineLength:
-  IgnoredPatterns: [(\A|\s)#]
+  AllowedPatterns: [(\A|\s)#]
   Max: 100
 
 Layout/MultilineArrayLineBreaks:

--- a/rubocop-able.gemspec
+++ b/rubocop-able.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name        = "rubocop-able"
-  spec.version     = "0.2.3"
+  spec.version     = "0.2.4"
   spec.authors     = "Able"
   spec.email       = "engineering@able.co"
 
@@ -13,6 +13,6 @@ Gem::Specification.new do |spec|
 
   spec.files       = Dir["README.md", "LICENSE", "config/*.yml"]
 
-  spec.add_dependency "rubocop", "~> 1.18"
-  spec.add_dependency "rubocop-rails", "~> 2.8.1"
+  spec.add_dependency "rubocop", "~> 1.28.2"
+  spec.add_dependency "rubocop-rails", "~> 2.14.2"
 end


### PR DESCRIPTION
While using this Gem we faced some warnings and deprecation warnings such as:
```
`RuboCop::Cop::EnforceSuperclass` is deprecated and will be removed in RuboCop 2.0. Please upgrade to RuboCop Rails 2.9 or newer to continue.
`RuboCop::Cop::EnforceSuperclass` is deprecated and will be removed in RuboCop 2.0. Please upgrade to RuboCop Rails 2.9 or newer to continue.
`RuboCop::Cop::EnforceSuperclass` is deprecated and will be removed in RuboCop 2.0. Please upgrade to RuboCop Rails 2.9 or newer to continue.
`RuboCop::Cop::EnforceSuperclass` is deprecated and will be removed in RuboCop 2.0. Please upgrade to RuboCop Rails 2.9 or newer to continue.
Warning: obsolete parameter `IgnoredPatterns` (for `Layout/LineLength`) found in /Users/caian/.asdf/installs/ruby/3.0.4/lib/ruby/gems/3.0.0/gems/rubocop-able-0.2.3/config/default.yml
`IgnoredPatterns` has been renamed to `AllowedPatterns`.
Warning: obsolete parameter `IgnoredPatterns` (for `Layout/LineLength`) found in .rubocop.yml
`IgnoredPatterns` has been renamed to `AllowedPatterns`
```

This PR could be used to start some efforts to fix those.